### PR TITLE
Add research content pages and dynamic episode loading

### DIFF
--- a/docs/assets/app.js
+++ b/docs/assets/app.js
@@ -88,13 +88,24 @@ function attachOpenHandlers(selector){
   });
 }
 
-function showEpisodePage(data) {
+async function showEpisodePage(data) {
   closeDrawer();
   mainView.hidden = true;
   episodeView.hidden = false;
 
   episodeTitle.textContent = data.title;
-  episodeContent.innerHTML = `<p>${data.desc}</p>`;
+
+  if (data.contentUrl) {
+    try {
+      const res = await fetch(data.contentUrl, { cache: 'no-store' });
+      const html = await res.text();
+      episodeContent.innerHTML = html;
+    } catch (e) {
+      episodeContent.innerHTML = `<p>${data.desc}</p>`;
+    }
+  } else {
+    episodeContent.innerHTML = `<p>${data.desc}</p>`;
+  }
 
   window.scrollTo(0, 0);
   backBtn.focus();
@@ -134,6 +145,7 @@ function renderTimeline(items) {
     el.dataset.themes = (item.themes || []).join(', ');
     el.dataset.desc = item.desc || '';
     el.dataset.slug = item.slug;
+    el.dataset.contentUrl = item.contentUrl || '';
     el.innerHTML = `<div class="eyebrow">Era</div><div class="name">${item.title}</div><div class="meta">${item.era}</div>`;
     wrap.appendChild(el);
   });
@@ -157,6 +169,7 @@ function renderThemes(items) {
     el.dataset.linked = (item.linked || []).join(', ');
     el.dataset.desc = item.desc || '';
     el.dataset.slug = item.slug;
+    el.dataset.contentUrl = item.contentUrl || '';
     el.innerHTML = `<h3>${item.title}</h3><p>${item.summary || 'Cross-cultural idea.'}</p>`;
     wrap.appendChild(el);
   });
@@ -446,5 +459,5 @@ showEpisodePage = function(data){
   params.set('mode', 'timeline');
   if (data.slug) params.set('episode', data.slug);
   location.hash = `#${params.toString()}`;
-  originalShowEpisodePage(data);
+  return originalShowEpisodePage(data);
 };

--- a/docs/assets/data.json
+++ b/docs/assets/data.json
@@ -5,28 +5,32 @@
       "era": "c. 2600–1200 BCE",
       "themes": ["Dream Realms", "Fate & Omens"],
       "desc": "Dreams as divine command; the traveling soul; royal dream-omen politics.",
-      "slug": "mesopotamia"
+      "slug": "mesopotamia",
+      "contentUrl": "./content/mesopotamia.html"
     },
     {
       "title": "Egypt",
       "era": "c. 2500–300 BCE",
       "themes": ["Soul Architecture", "Judgment"],
       "desc": "Ka & Ba, the weighing of the heart, and dream-books as guidance.",
-      "slug": "egypt"
+      "slug": "egypt",
+      "contentUrl": "./content/egypt.html"
     },
     {
       "title": "Greece I — Asclepian Temples",
       "era": "c. 500–200 BCE",
       "themes": ["Healing", "Dreams"],
       "desc": "Ritual sleep (enkóimesis); snakes, water, silence; recorded cures by priests.",
-      "slug": "greece-asclepian"
+      "slug": "greece-asclepian",
+      "contentUrl": "./content/greece-asclepian.html"
     },
     {
       "title": "Greece II — Orphic & Platonic Psyche",
       "era": "c. 500–300 BCE",
       "themes": ["Soul Architecture", "Purification"],
       "desc": "Orphic soul-prison myth; Platonic tripartite psyche and moral cultivation.",
-      "slug": "greece-psyche"
+      "slug": "greece-psyche",
+      "contentUrl": "./content/greece-psyche.html"
     }
   ],
   "themes": [

--- a/docs/content/egypt.html
+++ b/docs/content/egypt.html
@@ -1,0 +1,8 @@
+<h2>Egyptian Soul Architecture</h2>
+<p>Ancient Egyptians pictured a person as a network of bodily and spiritual parts. Preservation of the body and ethical living allowed these facets to reunite after death.</p>
+<ul>
+  <li><strong>Ka</strong>: the life-force that required offerings to endure.</li>
+  <li><strong>Ba</strong>: a mobile personality, often shown as a human-headed bird visiting the tomb each night.</li>
+  <li><strong>Akh</strong>: an enlightened spirit formed when Ka and Ba were harmonized.</li>
+</ul>
+<p>Mummification, offering cults, and the Opening of the Mouth ceremony animated these elements, leading to the weighing of the heart against the feather of Ma'at.</p>

--- a/docs/content/greece-asclepian.html
+++ b/docs/content/greece-asclepian.html
@@ -1,0 +1,7 @@
+<h2>Asclepian Dream Healing</h2>
+<p>Sanctuaries of Asclepius functioned as holistic hospitals. After purification, patients slept in the abaton where sacred snakes roamed and silence set the stage for divine dreams.</p>
+<ul>
+  <li>Visions of the god offered cures or symbolic prescriptions interpreted by temple priests.</li>
+  <li>Inscriptions known as <em>iamata</em> celebrated recoveries from blindness, paralysis and other ailments.</li>
+  <li>The ritual environment and expectation of epiphany worked together as an early form of psychotherapy.</li>
+</ul>

--- a/docs/content/greece-psyche.html
+++ b/docs/content/greece-psyche.html
@@ -1,0 +1,7 @@
+<h2>Orphic and Platonic Soul</h2>
+<p>Orphic traditions taught that humans inherit a divine spark within a Titanic body, making life a tension between heavenly origin and earthly desire.</p>
+<ul>
+  <li>Ascetic rituals and remembrance of one's divine ancestry aimed to liberate the soul from cycles of rebirth.</li>
+  <li>Plato's tripartite psyche cast reason as a charioteer directing spirited and appetitive horses toward the realm of Forms.</li>
+  <li>Both perspectives urged purification and philosophical discipline to restore the soul's kinship with the divine.</li>
+</ul>

--- a/docs/content/mesopotamia.html
+++ b/docs/content/mesopotamia.html
@@ -1,0 +1,9 @@
+<h2>Mesopotamian Dream Traditions</h2>
+<p>In ancient Mesopotamia, dreams were treated as direct channels from the divine. The soul was believed to wander beyond the body at night, receiving messages that guided both kings and commoners.</p>
+<h3>Narrative Highlights</h3>
+<ul>
+  <li><strong>Epic of Gilgamesh</strong>: Foreshadowing Enkidu's arrival and offering guidance on dangerous quests.</li>
+  <li><strong>Gudea of Lagash</strong>: Visionary commands to build temples legitimized political authority.</li>
+  <li><strong>Dumuzi's Prophecy</strong>: Detailed symbols interpreted by his sister predicted his downfall.</li>
+</ul>
+<p>These accounts reveal a culture where dream interpreters translated nocturnal visions into statecraft, ritual, and personal transformation.</p>


### PR DESCRIPTION
## Summary
- Link timeline entries to new HTML content pages derived from research.
- Load episode content dynamically via `contentUrl` for richer in-page detail.

## Testing
- `npm test` *(fails: package.json missing)*


------
https://chatgpt.com/codex/tasks/task_e_6896785a0c3c83239e073835c4affc87